### PR TITLE
RC2 publish - integration changes 

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,12 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
    <packageSources>
-    <add key="aspnetrelease" value="https://www.myget.org/F/aspnetrelease/api/v3/index.json" />
     <add key="myget" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="applicationinsights" value="https://www.myget.org/F/applicationinsights-sdk-labs/api/v3/index.json" />
-    <add key="aspnetcontrib" value="https://www.myget.org/F/aspnet-contrib/api/v3/index.json" />
-	<add key="aspnetcirelease" value="https://www.myget.org/F/aspnetcirelease/api/v3/index.json" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />

--- a/src/NuGet.Services.Staging.Manager/Startup.cs
+++ b/src/NuGet.Services.Staging.Manager/Startup.cs
@@ -111,8 +111,6 @@ namespace NuGet.Services.Staging.Manager
                 applicationBuilder.UseDeveloperExceptionPage();
             }
 
-            applicationBuilder.UseIISPlatformHandler();
-
             // Add Application Insights monitoring to the request pipeline as a very first middleware.
             applicationBuilder.UseApplicationInsightsRequestTelemetry();
 

--- a/src/NuGet.Services.Staging.Manager/project.json
+++ b/src/NuGet.Services.Staging.Manager/project.json
@@ -13,7 +13,6 @@
         "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-rc2-*",
         "Microsoft.AspNetCore.Diagnostics": "1.0.0-rc2-*",
         "Microsoft.AspNetCore.Http.Abstractions": "1.0.0-rc2-*",
-        "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-rc2-*",
         "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-*",
         "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-*",
         "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-*",
@@ -33,7 +32,7 @@
         "NuGet.Services.Logging": "2.0.0-rc2-*",
         "Microsoft.EntityFrameworkCore.Tools": {
             "type": "build",
-            "version": "1.0.0-rc2-*"
+            "version": "1.0.0-preview1-*"
         }
     },
 
@@ -43,8 +42,15 @@
     "tools": {
         "Microsoft.EntityFrameworkCore.Tools": {
             "imports": [ "portable-net451+win8" ],
-            "version": "1.0.0-rc2-*"
+            "version": "1.0.0-preview1-*"
+        },
+        "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
+            "version": "1.0.0-*",
+            "imports": "portable-net45+wp80+win8+wpa81+dnxcore50"
         }
+    },
+    "scripts": {
+        "postpublish": "dotnet publish-iis --publish-folder %publish:OutputPath% --framework %publish:FullTargetFramework%"
     },
 
     "userSecretsId": "aspnet5-Stage.Manager-20160219110719"

--- a/src/NuGet.Services.Staging.Manager/web.config
+++ b/src/NuGet.Services.Staging.Manager/web.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.web>
+    <httpRuntime targetFramework="4.5" maxQueryStringLength="12000" maxRequestLength="2000000000" requestPathInvalidCharacters="&lt;,&gt;,*,%,:,\,?" enableVersionHeader="false" />
+  </system.web>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
+    </handlers>
+    <aspNetCore processPath="..\MySite.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile="..\logs\stdout" />
+   <security>
+      <requestFiltering>
+        <!-- Clearing hidden segments and file extensions is done to allow Package IDs with ".vb", ".config", etc.
+                in their name to be served. As a result, we disable static file serving above. DO NOT change these settings
+                without a security review -->
+        <fileExtensions>
+          <clear />
+        </fileExtensions>
+        <hiddenSegments>
+          <clear />
+        </hiddenSegments>
+        <!-- maxAllowedContentLength = 250MB * 1024 * 1024 = 262144000 -->
+        <requestLimits maxQueryString="12000" maxAllowedContentLength="262144000" />
+      </requestFiltering>
+    </security>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
Since RC2 is publicly available on NuGet.org, changing the feed list to stop using private myget feeds. In addition, fixing IIS integration.