### PR TITLE
Search improvements

### DIFF
--- a/src/NuGet.Services.Staging.Search/DatabaseSearchService.cs
+++ b/src/NuGet.Services.Staging.Search/DatabaseSearchService.cs
@@ -76,7 +76,7 @@ namespace NuGet.Services.Staging.Search
             var searchResults = ApplyStageFilter(stageKey);
             searchResults = ApplyIncludePrerelease(searchResults, includePrerelease);
 
-            return searchResults.Where(x => idsList.Contains(x.Id)).ToImmutableList();
+            return searchResults.Where(x => idsList.Contains(x.Id)).OrderBy(x => x.Id).ToImmutableList();
         }
 
         private IQueryable<PackageMetadata> ApplyStageFilter(int stageKey)

--- a/test/NuGet.Services.Staging.Test.UnitTest/Infrastructure/DataMockHelper.cs
+++ b/test/NuGet.Services.Staging.Test.UnitTest/Infrastructure/DataMockHelper.cs
@@ -12,22 +12,21 @@ namespace NuGet.Services.Staging.Test.UnitTest
     public static class DataMockHelper
     {
         public static UserInformation DefaultUser = new UserInformation { UserKey = 2, UserName = "testUser" };
+        public const int DefaultStageKey = 1;
 
         public static Stage AddMockStage(this StageContextMock stageContextMock)
         {
-            const int stageKey = 1;
-
             var member = new StageMembership
             {
                 Key = 1,
                 MembershipType = MembershipType.Owner,
-                StageKey = stageKey,
+                StageKey = DefaultStageKey,
                 UserKey = DefaultUser.UserKey
             };
 
             var stage = new Stage
             {
-                Key = stageKey,
+                Key = DefaultStageKey,
                 Id = Guid.NewGuid().ToString(),
                 DisplayName = "DefaultStage",
                 Memberships = new List<StageMembership> { member },
@@ -76,7 +75,8 @@ namespace NuGet.Services.Staging.Test.UnitTest
 
         public static PackageMetadata CreateDefaultPackageMetadata(
             string id = TestPackage.DefaultId,
-            string version = TestPackage.DefaultVersion)
+            string version = TestPackage.DefaultVersion,
+            int stageKey = DefaultStageKey)
         {
             return new PackageMetadata
             {
@@ -91,7 +91,8 @@ namespace NuGet.Services.Staging.Test.UnitTest
                 Tags = TestPackage.DefaultTags,
                 Summary = TestPackage.DefaultSummary,
                 Title = TestPackage.DefaultTitle,
-                IsPrerelease = true
+                IsPrerelease = true,
+                StageKey = stageKey
             };
         }
     }

--- a/test/NuGet.Services.Staging.Test.UnitTest/SearchUnitTests/DatabaseSearchUnitTests.cs
+++ b/test/NuGet.Services.Staging.Test.UnitTest/SearchUnitTests/DatabaseSearchUnitTests.cs
@@ -157,7 +157,7 @@ namespace NuGet.Services.Staging.Test.UnitTest
         }
 
         [Fact]
-        public void VerifyStageFiltering()
+        public void VerifyApplyQueryParametersFilteringByStage()
         {
             // Arrange
             var stage1Packages = GeneratePackageList(stageKey: DataMockHelper.DefaultStageKey);
@@ -180,14 +180,14 @@ namespace NuGet.Services.Staging.Test.UnitTest
         }
 
         [Fact]
-        public void VerifyQueryParsing()
+        public void VerifySearch()
         {
             // Arrange
             var stage = _stageContextMock.AddMockStage();
             stage.Id = DefaultStageId;
 
             var allPackages = GeneratePackageList(stage.Key);
-            _stageContextMock.Object.PackagesMetadata.AddRange(allPackages);
+            _stageContextMock.Object.PackagesMetadata.AddRange(allPackages.Reverse());
 
             string query = "q=title2&skip=1&take=2&prerelease=false";
 
@@ -196,7 +196,7 @@ namespace NuGet.Services.Staging.Test.UnitTest
 
             // Assert
             var expectedPackages =
-                _stageContextMock.Object.PackagesMetadata.Where(p => p.IsPrerelease == false && p.Title.Contains("title2")).Skip(1).Take(2).ToList();
+                _stageContextMock.Object.PackagesMetadata.Where(p => p.IsPrerelease == false && p.Title.Contains("title2")).OrderBy(x => x.Id).Skip(1).Take(2).ToList();
 
             var expectedJson =
                 new JObject


### PR DESCRIPTION
1. In case a package has multiple versions, there was a bug in the number of results displayed. If package X has 5 versions, and run the query with take = 10, then ApplyQueryParameters would return 10 results, where 5 of them are the same package id (X). After conversion to json format, all the versions of package X would end up as a single result. Meaning the search will return 6 results instead of 10. 
I fixed this issues by first getting a list of unique ids that should be returned by search, and then getting all the packages belonging to those ids.

2. Ordering - simple sort by id.

@maartenba @xavierdecoster  
 