### PR TITLE
List command - client side

### DIFF
--- a/src/NuGet.CommandLine.StagingExtensions/StageCommand.cs
+++ b/src/NuGet.CommandLine.StagingExtensions/StageCommand.cs
@@ -76,22 +76,12 @@ namespace NuGet.CommandLine.StagingExtensions
 
         private bool TryParseArguments(out SubCommand subCommand, out string parameter)
         {
-            subCommand = SubCommand.None;
             parameter = string.Empty;
-
             string commandString = Arguments[0];
 
-            if (string.Equals(commandString, "create", StringComparison.InvariantCultureIgnoreCase))
+            if (!Enum.TryParse(commandString, ignoreCase: true, result: out subCommand))
             {
-                subCommand = SubCommand.Create;
-            }
-            else if (string.Equals(commandString, "drop", StringComparison.InvariantCultureIgnoreCase))
-            {
-                subCommand = SubCommand.Drop;
-            }
-            else if (string.Equals(commandString, "list", StringComparison.InvariantCultureIgnoreCase))
-            {
-                subCommand = SubCommand.List;
+                subCommand = SubCommand.None;
             }
 
             if (subCommand == SubCommand.Create || subCommand == SubCommand.Drop)

--- a/src/NuGet.CommandLine.StagingExtensions/StageCommand.cs
+++ b/src/NuGet.CommandLine.StagingExtensions/StageCommand.cs
@@ -14,7 +14,7 @@ using NuGet.Protocol.Core.v3;
 namespace NuGet.CommandLine.StagingExtensions
 {
     [Command(resourceType: typeof(StagingResources), commandName: "stage", descriptionResourceName: "StageCommandDescription",
-       MinArgs = 0, MaxArgs = 0, UsageSummaryResourceName = "StageCommandUsageSummary", UsageExampleResourceName = "StageCommandUsageExample")]
+       MinArgs = 1, MaxArgs = 2, UsageSummaryResourceName = "StageCommandUsageSummary", UsageExampleResourceName = "StageCommandUsageExample")]
     public class StageCommand : Command
     {
         [Option(typeof(StagingResources), "StageCommandCreateDescription")]
@@ -23,16 +23,63 @@ namespace NuGet.CommandLine.StagingExtensions
         [Option(typeof(StagingResources), "StageCommandDropDescription")]
         public string Drop { get; set; }
 
+        [Option(typeof(StagingResources), "StageCommandListDescription")]
+        public string List { get; set; }
+
         [Option(typeof(StagingResources), "StageCommandSourceDescription")]
         public string Source { get; set; }
 
         [Option(typeof(StagingResources), "StageCommandApiKeyDescription")]
         public string ApiKey { get; set; }
 
+        private enum SubCommand
+        {
+            None,
+            Create,
+            Drop,
+            List
+        }
+
+        private bool TryParseArguments(out SubCommand subCommand, out string parameter)
+        {
+            subCommand = SubCommand.None;
+            parameter = string.Empty;
+
+            string commandString = Arguments[0];
+
+            if (string.Equals(commandString, "create", StringComparison.InvariantCultureIgnoreCase))
+            {
+                subCommand = SubCommand.Create;
+            }
+            else if (string.Equals(commandString, "drop", StringComparison.InvariantCultureIgnoreCase))
+            {
+                subCommand = SubCommand.Drop;   
+            }
+            else if(string.Equals(commandString, "list", StringComparison.InvariantCultureIgnoreCase))
+            {
+                subCommand = SubCommand.List;
+            }
+
+            if (subCommand == SubCommand.Create || subCommand == SubCommand.Drop)
+            {
+                if (Arguments.Count < 2)
+                {
+                    return false;
+                }
+
+                parameter = Arguments[1];
+            }
+
+            return subCommand != SubCommand.None;
+        }
+
         public override async Task ExecuteCommandAsync()
         {
             // Verify input
-            if (string.IsNullOrEmpty(Create) == string.IsNullOrEmpty(Drop))
+            SubCommand subCommand;
+            string parameter;
+
+            if (!TryParseArguments(out subCommand, out parameter))
             {
                 HelpCommand.ViewHelpForCommand(CommandAttribute.CommandName);
                 return;
@@ -46,13 +93,13 @@ namespace NuGet.CommandLine.StagingExtensions
 
             var stageManagementResource = await GetStageManagementResource(source);
 
-            if (!string.IsNullOrEmpty(Create))
+            if (subCommand == SubCommand.Create)
             {
-                await CreateStage(stageManagementResource, apiKey, Create);
+                await CreateStage(stageManagementResource, apiKey, parameter);
             }
-            else if (!string.IsNullOrEmpty(Drop))
+            else if (subCommand == SubCommand.Drop)
             {
-                await DropStage(stageManagementResource, apiKey, Drop);
+                await DropStage(stageManagementResource, apiKey, parameter);
             }
         }
 

--- a/src/NuGet.CommandLine.StagingExtensions/StageManagementResource.cs
+++ b/src/NuGet.CommandLine.StagingExtensions/StageManagementResource.cs
@@ -124,7 +124,7 @@ namespace NuGet.CommandLine.StagingExtensions
             var result = await _httpSource.ProcessResponseAsync(
                 () =>
                 {
-                    var request = new HttpRequestMessage(HttpMethod.Get, new Uri(_stageServiceUri, $"{StagePath}"));
+                    var request = new HttpRequestMessage(HttpMethod.Get, new Uri(_stageServiceUri, StagePath));
                     request.Headers.Add(ApiKeyHeader, apiKey);
 
                     return request;

--- a/src/NuGet.CommandLine.StagingExtensions/StageManagementResource.cs
+++ b/src/NuGet.CommandLine.StagingExtensions/StageManagementResource.cs
@@ -22,11 +22,11 @@ namespace NuGet.CommandLine.StagingExtensions
         private const string MediaType = "application/json";
 
         private readonly HttpSource _httpSource;
-        private readonly string _stageServiceUri;
+        private readonly Uri _stageServiceUri;
 
         public StageManagementResource(string stageServiceUri, HttpSource httpSource)
         {
-            _stageServiceUri = stageServiceUri;
+            _stageServiceUri = new Uri(stageServiceUri);
             _httpSource = httpSource;
         }
 
@@ -50,7 +50,7 @@ namespace NuGet.CommandLine.StagingExtensions
             var result = await _httpSource.ProcessResponseAsync(
                 () =>
                 {
-                    var request = new HttpRequestMessage(HttpMethod.Post, new Uri(new Uri(_stageServiceUri), StagePath));
+                    var request = new HttpRequestMessage(HttpMethod.Post, new Uri(_stageServiceUri, StagePath));
                     request.Headers.Add(ApiKeyHeader, apiKey);
 
                     request.Content = new StringContent("\"" + displayName + "\"", Encoding.UTF8);
@@ -91,7 +91,7 @@ namespace NuGet.CommandLine.StagingExtensions
             var result = await _httpSource.ProcessResponseAsync(
                 () =>
                 {
-                    var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(new Uri(_stageServiceUri), $"{StagePath}/{id}"));
+                    var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(_stageServiceUri, $"{StagePath}/{id}"));
                     request.Headers.Add(ApiKeyHeader, apiKey);
 
                     return request;
@@ -124,7 +124,7 @@ namespace NuGet.CommandLine.StagingExtensions
             var result = await _httpSource.ProcessResponseAsync(
                 () =>
                 {
-                    var request = new HttpRequestMessage(HttpMethod.Get, new Uri(new Uri(_stageServiceUri), $"{StagePath}"));
+                    var request = new HttpRequestMessage(HttpMethod.Get, new Uri(_stageServiceUri, $"{StagePath}"));
                     request.Headers.Add(ApiKeyHeader, apiKey);
 
                     return request;

--- a/src/NuGet.CommandLine.StagingExtensions/StagingResources.Designer.cs
+++ b/src/NuGet.CommandLine.StagingExtensions/StagingResources.Designer.cs
@@ -135,6 +135,51 @@ namespace NuGet.CommandLine.StagingExtensions {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Creation date.
+        /// </summary>
+        internal static string HeaderStageCreationDate {
+            get {
+                return ResourceManager.GetString("HeaderStageCreationDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expiration date.
+        /// </summary>
+        internal static string HeaderStageExpirationDate {
+            get {
+                return ResourceManager.GetString("HeaderStageExpirationDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Feed.
+        /// </summary>
+        internal static string HeaderStageFeed {
+            get {
+                return ResourceManager.GetString("HeaderStageFeed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name.
+        /// </summary>
+        internal static string HeaderStageName {
+            get {
+                return ResourceManager.GetString("HeaderStageName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Status.
+        /// </summary>
+        internal static string HeaderStageStatus {
+            get {
+                return ResourceManager.GetString("HeaderStageStatus", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to the NuGet gallery.
         /// </summary>
         internal static string LiveFeed {
@@ -189,6 +234,15 @@ namespace NuGet.CommandLine.StagingExtensions {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Get a list of the stages you own.
+        /// </summary>
+        internal static string StageCommandListDescription {
+            get {
+                return ResourceManager.GetString("StageCommandListDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Specifies the server URL. If not specified, nuget.org is used unless DefaultPushSource config value is set in the NuGet config file. The specified server must support staging..
         /// </summary>
         internal static string StageCommandSourceDescription {
@@ -222,6 +276,15 @@ namespace NuGet.CommandLine.StagingExtensions {
         internal static string StageIdShouldNotBeEmpty {
             get {
                 return ResourceManager.GetString("StageIdShouldNotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No stages were found..
+        /// </summary>
+        internal static string StageListNoStagesFound {
+            get {
+                return ResourceManager.GetString("StageListNoStagesFound", resourceCulture);
             }
         }
         

--- a/src/NuGet.CommandLine.StagingExtensions/StagingResources.resx
+++ b/src/NuGet.CommandLine.StagingExtensions/StagingResources.resx
@@ -143,6 +143,21 @@ Feed URI: {1}</value>
   <data name="DroppedStageMessage" xml:space="preserve">
     <value>Stage '{0}' was dropped.</value>
   </data>
+  <data name="HeaderStageCreationDate" xml:space="preserve">
+    <value>Creation date</value>
+  </data>
+  <data name="HeaderStageExpirationDate" xml:space="preserve">
+    <value>Expiration date</value>
+  </data>
+  <data name="HeaderStageFeed" xml:space="preserve">
+    <value>Feed</value>
+  </data>
+  <data name="HeaderStageName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="HeaderStageStatus" xml:space="preserve">
+    <value>Status</value>
+  </data>
   <data name="LiveFeed" xml:space="preserve">
     <value>the NuGet gallery</value>
   </data>
@@ -161,6 +176,9 @@ Feed URI: {1}</value>
   <data name="StageCommandDropDescription" xml:space="preserve">
     <value>Drop a stage you own</value>
   </data>
+  <data name="StageCommandListDescription" xml:space="preserve">
+    <value>Get a list of the stages you own</value>
+  </data>
   <data name="StageCommandSourceDescription" xml:space="preserve">
     <value>Specifies the server URL. If not specified, nuget.org is used unless DefaultPushSource config value is set in the NuGet config file. The specified server must support staging.</value>
   </data>
@@ -173,6 +191,9 @@ stage -drop 4b139cb7-c4d4-4541-8c05-0f41ba5ab945 -source https://api.nuget.org/v
   </data>
   <data name="StageIdShouldNotBeEmpty" xml:space="preserve">
     <value>Stage id should not be empty</value>
+  </data>
+  <data name="StageListNoStagesFound" xml:space="preserve">
+    <value>No stages were found.</value>
   </data>
   <data name="StagingNotSupported" xml:space="preserve">
     <value>The specified server does not support staging.</value>

--- a/test/NuGet.CommandLine.Staging.UnitTests/StagingCommandUnitTests.cs
+++ b/test/NuGet.CommandLine.Staging.UnitTests/StagingCommandUnitTests.cs
@@ -26,7 +26,7 @@ namespace NuGet.CommandLine.Staging.UnitTests
         public void StageCommand_WhenSourceNotProvidedErrorIsShown()
         {
             // Act
-            string[] args = { "stage", "-create", "abc" };
+            string[] args = { "stage", "create", "abc" };
             var result = CommandRunner.Run(NuGetExe, Directory.GetCurrentDirectory(), string.Join(" ", args), true);
 
             // Assert
@@ -39,7 +39,7 @@ namespace NuGet.CommandLine.Staging.UnitTests
         public void StageCommand_WhenApiKeyNotProvidedErrorIsShown()
         {
             // Act
-            string[] args = { "stage", "-create", "abc", "-Source", "http://api.nuget.org/v3/index.json" };
+            string[] args = { "stage", "create", "abc", "-Source", "http://api.nuget.org/v3/index.json" };
             var result = CommandRunner.Run(NuGetExe, Directory.GetCurrentDirectory(), string.Join(" ", args), true);
 
             // Assert
@@ -52,7 +52,7 @@ namespace NuGet.CommandLine.Staging.UnitTests
         public void StageCommand_WhenBadParametersProvidedHelpIsShown()
         {
             // Act
-            string[] args = { "stage", "-create", "abc", "-drop", "cde" };
+            string[] args = { "stage", "create", "abc", "drop", "cde" };
             var result = CommandRunner.Run(NuGetExe, Directory.GetCurrentDirectory(), string.Join(" ", args), true);
 
             // Assert
@@ -68,7 +68,7 @@ namespace NuGet.CommandLine.Staging.UnitTests
                 serverV3.Start();
 
                 // Act
-                string[] args = { "stage", "-create", "abc", "-Source", serverV3.Uri + "index.json", "-ApiKey", "123" };
+                string[] args = { "stage", "create", "abc", "-Source", serverV3.Uri + "index.json", "-ApiKey", "123" };
                 var result = CommandRunner.Run(NuGetExe, Directory.GetCurrentDirectory(), string.Join(" ", args), true);
 
                 serverV3.Stop();
@@ -108,7 +108,7 @@ namespace NuGet.CommandLine.Staging.UnitTests
                     stagingServer.Start();
 
                     // Act
-                    string[] args = {"stage", "-create", "abc", "-Source", serverV3.Uri + "index.json", "-ApiKey", "123"};
+                    string[] args = {"stage", "create", "abc", "-Source", serverV3.Uri + "index.json", "-ApiKey", "123"};
                     var result = CommandRunner.Run(NuGetExe, Directory.GetCurrentDirectory(), string.Join(" ", args), true);
 
                     serverV3.Stop();
@@ -147,7 +147,7 @@ namespace NuGet.CommandLine.Staging.UnitTests
                     stagingServer.Start();
 
                     // Act
-                    string[] args = { "stage", "-create", "abc", "-Source", serverV3.Uri + "index.json", "-ApiKey", "123" };
+                    string[] args = { "stage", "create", "abc", "-Source", serverV3.Uri + "index.json", "-ApiKey", "123" };
                     var result = CommandRunner.Run(NuGetExe, Directory.GetCurrentDirectory(), string.Join(" ", args), true);
 
                     serverV3.Stop();
@@ -189,7 +189,7 @@ namespace NuGet.CommandLine.Staging.UnitTests
                     stagingServer.Start();
 
                     // Act
-                    string[] args = { "stage", "-drop", stageId, "-Source", serverV3.Uri + "index.json", "-ApiKey", "123", "-NonInteractive" };
+                    string[] args = { "stage", "drop", stageId, "-Source", serverV3.Uri + "index.json", "-ApiKey", "123", "-NonInteractive" };
                     var result = CommandRunner.Run(NuGetExe, Directory.GetCurrentDirectory(), string.Join(" ", args), true);
 
                     serverV3.Stop();
@@ -229,7 +229,7 @@ namespace NuGet.CommandLine.Staging.UnitTests
                     stagingServer.Start();
 
                     // Act
-                    string[] args = { "stage", "-drop", stageId, "-Source", serverV3.Uri + "index.json", "-ApiKey", "123", "-NonInteractive" };
+                    string[] args = { "stage", "drop", stageId, "-Source", serverV3.Uri + "index.json", "-ApiKey", "123", "-NonInteractive" };
                     var result = CommandRunner.Run(NuGetExe, Directory.GetCurrentDirectory(), string.Join(" ", args), true);
 
                     serverV3.Stop();


### PR DESCRIPTION
1. Changes the way stage command parses arguments to allow "sub-command" like behavior.
2. Added List command - list all the stages a user owns.

@ryuyu @maartenba @xavierdecoster @emgarten @joelverhagen 
